### PR TITLE
Get the new version of nette/neon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "ext-intl": "*",
     "ext-tokenizer": "*",
     "nette/di": "^3.0",
-    "nette/neon": "v3.0.0-beta1",
+    "nette/neon": "^3.0",
     "nette/safe-stream": "^2.3",
     "nette/utils": "^3.0",
     "psr/log": "^1.0"


### PR DESCRIPTION
There is no BC. https://github.com/nette/neon/compare/v3.0.0-beta1...v3.0.0-RC1